### PR TITLE
fix: mitigate timing attack in login flow (#54)

### DIFF
--- a/services/auth/src/main/java/com/rido/auth/service/HashGenerator.java
+++ b/services/auth/src/main/java/com/rido/auth/service/HashGenerator.java
@@ -1,0 +1,12 @@
+
+import org.springframework.security.crypto.argon2.Argon2PasswordEncoder;
+
+public class HashGenerator {
+    public static void main(String[] args) {
+        // Matches SecurityConfig.java:
+        // saltLength=16, hashLength=32, parallelism=1, memory=4096 (1<<12), iterations=3
+        Argon2PasswordEncoder encoder = new Argon2PasswordEncoder(16, 32, 1, 4096, 3);
+        String hash = encoder.encode("dummy_password_for_timing_mitigation");
+        System.out.println("GENERATED_HASH=" + hash);
+    }
+}

--- a/services/auth/src/main/java/com/rido/auth/service/LoginService.java
+++ b/services/auth/src/main/java/com/rido/auth/service/LoginService.java
@@ -22,7 +22,7 @@ public class LoginService {
      * Used to perform fake password verification when user doesn't exist.
      * This ensures constant-time response regardless of whether the user exists.
      */
-    private static final String DUMMY_PASSWORD_HASH = "$argon2id$v=19$m=65536,t=3,p=4$dHlwZXNpeC5jb20tc2VjdXJl$qwerty123456789012345678901234567890123456789012";
+    private static final String DUMMY_PASSWORD_HASH = "$argon2id$v=19$m=4096,t=3,p=1$kRp/g995IaBi1gf17tcLFQ$1wfk5V0lsRbZBcYuHZnZjw6/Vna/QKOsiRyxjvmvku4";
 
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;

--- a/services/auth/src/test/java/com/rido/auth/service/HashGeneratorTest.java
+++ b/services/auth/src/test/java/com/rido/auth/service/HashGeneratorTest.java
@@ -1,0 +1,17 @@
+package com.rido.auth.service;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.security.crypto.argon2.Argon2PasswordEncoder;
+
+public class HashGeneratorTest {
+    @Test
+    public void generateHash() {
+        Argon2PasswordEncoder encoder = new Argon2PasswordEncoder(16, 32, 1, 4096, 3);
+        String hash = encoder.encode("dummy_password");
+        try {
+            java.nio.file.Files.writeString(java.nio.file.Path.of("generated_hash.txt"), hash);
+        } catch (java.io.IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}


### PR DESCRIPTION
fix: mitigate timing attack in login flow (#54 )
Synchronize dummy password hash parameters with actual SecurityConfig settings to ensure constant-time response for invalid users.
Changes:
- Update DUMMY_PASSWORD_HASH in LoginService to use m=4096, t=3, p=1
- Match Argon2id work factor of real password verification to eliminate timing leaks
- Fixes discrepancy where invalid users took longer due to higher dummy cost
Verification:
- verified 02-timing-attack-mitigation.sh passes with <100ms delta
resolve #54  